### PR TITLE
replace config module

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ var (
 
 func main() {
 	// 加载项目配置文件
-	opt := option.LoadConfig()
+	opt := option.MustLoadConfig()
 
 	// 加载全局日志配置，完成日志的初始化操作
 	log := logger.BuildLogger(opt.Logger)

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.14
 
 require (
 	github.com/go-chi/chi/v5 v5.0.3
+	github.com/go-kratos/kratos/contrib/config/apollo/v2 v2.0.0-20220801155503-fea863e7837e
+	github.com/go-kratos/kratos/v2 v2.4.0
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/jacexh/gopkg/chi-middleware v0.0.0-20210825023717-c4d755320c90
+	github.com/jacexh/gopkg/config v0.1.0
 	github.com/jacexh/gopkg/zaprotate v0.0.0-20210730080640-fc0be4bdb2ea
-	github.com/jacexh/multiconfig v0.1.2
-	github.com/pkg/errors v0.9.1 // indirect
 	go.uber.org/zap v1.18.1
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	xorm.io/xorm v1.0.5
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacexh/golang-ddd-template
 
-go 1.14
+go 1.18
 
 require (
 	github.com/go-chi/chi/v5 v5.0.3

--- a/internal/option/fakesource.go
+++ b/internal/option/fakesource.go
@@ -1,0 +1,66 @@
+package option
+
+import (
+	kconf "github.com/go-kratos/kratos/v2/config"
+	"github.com/jacexh/gopkg/config"
+)
+
+type (
+	fakeSource struct {
+		s kconf.Source
+	}
+
+	fakeWatcher struct {
+		w kconf.Watcher
+	}
+)
+
+func (f fakeSource) Load() ([]*config.KeyValue, error) {
+	kvs, err := f.s.Load()
+	if err != nil {
+		return nil, err
+	}
+	var ret = make([]*config.KeyValue, len(kvs))
+	for i, kv := range kvs {
+		ret[i] = &config.KeyValue{
+			Key:    kv.Key,
+			Value:  kv.Value,
+			Format: kv.Format,
+		}
+	}
+	return ret, nil
+}
+
+func (f fakeSource) Watch() (config.Watcher, error) {
+	w, err := f.s.Watch()
+	if err != nil {
+		return nil, err
+	}
+	return fakeWatcher{w: w}, err
+}
+
+func (fw fakeWatcher) Next() ([]*config.KeyValue, error) {
+	kvs, err := fw.w.Next()
+	if err != nil {
+		return nil, err
+	}
+	var ret = make([]*config.KeyValue, len(kvs))
+	for i, kv := range kvs {
+		ret[i] = &config.KeyValue{
+			Key:    kv.Key,
+			Value:  kv.Value,
+			Format: kv.Format,
+		}
+	}
+	return ret, nil
+}
+
+func (fw fakeWatcher) Stop() error {
+	return fw.w.Stop()
+}
+
+func convertSource(source kconf.Source) config.Source {
+	return fakeSource{
+		s: source,
+	}
+}


### PR DESCRIPTION
使用[github.com/jacexh/gopkg/config](https://github.com/jacexh/gopkg/tree/master/config)替换muticonfig最为新的配置模块。新增了数据源Apollo。
1. apollo可配置的环境变量：APOLLO_HOST，APOLLO_APPID，APOLLO_CLUSTER，APOLLO_NAMESPACE
2. 实现了一个fakeSource，将kratos包中的`interface Source`转化成符合gopkg包的`interface`，可以直接使用kratos中实现的数据源。
3. 将go mod中sdk版本升级到1.18